### PR TITLE
mysql supports unix socket

### DIFF
--- a/dbd/mysql/connection.c
+++ b/dbd/mysql/connection.c
@@ -26,7 +26,11 @@ static int connection_new(lua_State *L) {
 	    port = luaL_checkint(L, 5);
     case 4: 
 	if (lua_isnil(L, 4) == 0) 
-	    host = luaL_checkstring(L, 4);
+        host = luaL_checkstring(L, 4);
+        if (host[0] == '/') {
+            unix_socket = host;
+            host        = NULL;
+        };
     case 3:
 	if (lua_isnil(L, 3) == 0) 
 	    password = luaL_checkstring(L, 3);
@@ -59,6 +63,7 @@ static int connection_new(lua_State *L) {
     lua_setmetatable(L, -2);
 
     return 1;
+        
 }
 
 /*


### PR DESCRIPTION
mysql now supports unix socket, postgresql already has as you can see here: http://www.postgresql.org/docs/8.3/static/libpq-connect.html

basic usage:

```
local db = require 'DBI'
local con, err = assert(db.Connect('MySQL', 'tupana', 'tupana', 'r4nd0m', '/tmp/mariadb.sock', nil))
```
