### PR TITLE
Update pgsql driver to remove breaking include.

### DIFF
--- a/dbd/postgresql/dbd_postgresql.h
+++ b/dbd/postgresql/dbd_postgresql.h
@@ -1,5 +1,4 @@
 #include <libpq-fe.h>
-#include <postgres_fe.h>
 #include <dbd/common.h>
 
 /* 


### PR DESCRIPTION
The postgres_fe.h header file is not required by client libraries, only
the libpq-fe.h header file. Since the former is internal and not in the
default include this causes the build to break. Removing the line means
a successful build and code that connects, queries, inserts and updates
successfully.

Reference documentation (The format changes but include information is
the same going back to release 7.1):
http://www.postgresql.org/docs/9.4/interactive/libpq-build.html
